### PR TITLE
implement naive constant folding for list and literals

### DIFF
--- a/src/folder.rs
+++ b/src/folder.rs
@@ -1,0 +1,179 @@
+use crate::parser::{AstNode, BinaryOperator, UnaryOperator};
+use crate::value::Value;
+
+pub fn fold(node: AstNode) -> AstNode {
+    use AstNode::*;
+    match node {
+        Literal(_) | Variable(_) | Break | Continue => node,
+        UnaryOp { operator, operand } => {
+            let operand = Box::new(fold(*operand));
+            if let Literal(v) = operand.as_ref() {
+                if let Some(res) = eval_unary(operator.clone(), v.clone()) {
+                    return Literal(res);
+                }
+            }
+            UnaryOp { operator, operand }
+        }
+        BinaryOp { left, operator, right } => {
+            let left = Box::new(fold(*left));
+            let right = Box::new(fold(*right));
+            if let (Literal(lv), Literal(rv)) = (&*left, &*right) {
+                if let Some(res) = eval_binary(operator.clone(), lv.clone(), rv.clone()) {
+                    return Literal(res);
+                }
+            }
+            BinaryOp { left, operator, right }
+        }
+        List(items) => {
+            let items: Vec<AstNode> = items.into_iter().map(fold).collect();
+            if items.iter().all(|n| matches!(n, Literal(_))) {
+                let mut values = Vec::with_capacity(items.len());
+                for item in items {
+                    if let Literal(v) = item {
+                        values.push(v);
+                    }
+                }
+                if values.iter().all(|v| matches!(v, Value::Int(_))) {
+                    let ints: Vec<i64> = values
+                        .into_iter()
+                        .map(|v| if let Value::Int(i) = v { i } else { unreachable!() })
+                        .collect();
+                    Literal(Value::IntList(ints))
+                } else {
+                    Literal(Value::List(values))
+                }
+            } else {
+                List(items)
+            }
+        }
+        Dict(pairs) => {
+            let pairs: Vec<(String, AstNode)> = pairs
+                .into_iter()
+                .map(|(k, v)| (k, fold(v)))
+                .collect();
+            Dict(pairs)
+        }
+        Assignment { name, value } => Assignment {
+            name,
+            value: Box::new(fold(*value)),
+        },
+        Postfix { object, items, explicit_call } => Postfix {
+            object: Box::new(fold(*object)),
+            items: items.into_iter().map(fold).collect(),
+            explicit_call,
+        },
+        Call { name, args } => Call {
+            name,
+            args: args.into_iter().map(fold).collect(),
+        },
+        CallAnonymous { object, args } => CallAnonymous {
+            object: Box::new(fold(*object)),
+            args: args.into_iter().map(fold).collect(),
+        },
+        Index { object, index } => Index {
+            object: Box::new(fold(*object)),
+            index: Box::new(fold(*index)),
+        },
+        IndexAssign { object, index, value } => IndexAssign {
+            object: Box::new(fold(*object)),
+            index: Box::new(fold(*index)),
+            value: Box::new(fold(*value)),
+        },
+        Function { params, body } => Function {
+            params,
+            body: Box::new(fold(*body)),
+        },
+        Conditional { condition, true_branch, false_branch } => Conditional {
+            condition: Box::new(fold(*condition)),
+            true_branch: Box::new(fold(*true_branch)),
+            false_branch: false_branch.map(|b| Box::new(fold(*b))),
+        },
+        WhileLoop { condition, body } => WhileLoop {
+            condition: Box::new(fold(*condition)),
+            body: Box::new(fold(*body)),
+        },
+        ForLoop { count, body } => ForLoop {
+            count: Box::new(fold(*count)),
+            body: Box::new(fold(*body)),
+        },
+        Return(expr) => Return(expr.map(|e| Box::new(fold(*e)))),
+        Assert(expr) => Assert(Box::new(fold(*expr))),
+        Try(expr) => Try(Box::new(fold(*expr))),
+        Block(stmts) => Block(stmts.into_iter().map(fold).collect()),
+    }
+}
+
+fn eval_unary(op: UnaryOperator, val: Value) -> Option<Value> {
+    use UnaryOperator::*;
+    match op {
+        Negate => val.neg_value(),
+        Count => Some(Value::Int(val.len() as i64)),
+    }
+}
+
+fn eval_binary(op: BinaryOperator, left: Value, right: Value) -> Option<Value> {
+    use BinaryOperator::*;
+    match op {
+        Add => left.add(&right),
+        Subtract => left.subtract(&right),
+        Multiply => left.multiply(&right),
+        Power => left.power(&right),
+        Divide => left.divide(&right),
+        DivideDot => left.divide_dot(&right),
+        Modulo => left.modulo(&right),
+        ModuloDot => left.modulo_dot(&right),
+        Equal => Some(left.equals(&right)),
+        NotEqual => Some(left.not_equals(&right)),
+        LessThan => Some(left.less_than(&right)),
+        LessThanOrEqual => Some(left.less_than_or_equal(&right)),
+        GreaterThan => Some(left.greater_than(&right)),
+        GreaterThanOrEqual => Some(left.greater_than_or_equal(&right)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folds_simple_addition() {
+        let ast = AstNode::BinaryOp {
+            left: Box::new(AstNode::Literal(Value::Int(1))),
+            operator: BinaryOperator::Add,
+            right: Box::new(AstNode::Literal(Value::Int(1))),
+        };
+        let folded = fold(ast);
+        assert_eq!(folded, AstNode::Literal(Value::Int(2)));
+    }
+
+    #[test]
+    fn folds_list_addition_to_int_list() {
+        let l1 = AstNode::List(vec![
+            AstNode::Literal(Value::Int(1)),
+            AstNode::Literal(Value::Int(2)),
+            AstNode::Literal(Value::Int(3)),
+            AstNode::Literal(Value::Int(4)),
+        ]);
+        let l2 = AstNode::List(vec![
+            AstNode::Literal(Value::Int(3)),
+            AstNode::Literal(Value::Int(4)),
+            AstNode::Literal(Value::Int(5)),
+            AstNode::Literal(Value::Int(6)),
+        ]);
+        let ast = AstNode::BinaryOp {
+            left: Box::new(l1),
+            operator: BinaryOperator::Add,
+            right: Box::new(l2),
+        };
+        let folded = fold(ast);
+        assert_eq!(
+            folded,
+            AstNode::Literal(Value::IntList(vec![4, 6, 8, 10]))
+        );
+        if let AstNode::Literal(val) = folded {
+            assert_eq!(val.type_name_verbose(), "int-list");
+        } else {
+            panic!("expected literal");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod lexer;
 pub mod parser;
 pub mod repl;
 pub mod resolver;
+pub mod folder;
 pub mod utils;
 pub mod value;
 pub mod vm;

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -127,6 +127,7 @@ pub fn vm_get_ins(path: &String, debug: bool) -> WqResult<Vec<Instruction>> {
         eprintln!();
     }
     use crate::resolver::Resolver;
+    use crate::folder;
     let mut parser = Parser::new(tokens, src.clone());
     let ast = parser.parse()?;
     if debug {
@@ -135,6 +136,7 @@ pub fn vm_get_ins(path: &String, debug: bool) -> WqResult<Vec<Instruction>> {
     }
     let mut resolver = Resolver::new();
     let ast = resolver.resolve(ast);
+    let ast = folder::fold(ast);
     let mut compiler = Compiler::new();
     compiler.compile(&ast)?;
     compiler.fuse();
@@ -203,10 +205,12 @@ impl VmEvaluator {
             eprintln!("{tokens:?}");
         }
         use crate::resolver::Resolver;
+        use crate::folder;
         let mut parser = Parser::new(tokens, input.to_string());
         let ast = parser.parse()?;
         let mut resolver = Resolver::from_env(self.environment());
         let ast = resolver.resolve(ast);
+        let ast = folder::fold(ast);
         if self.debug {
             eprintln!("=====AST=====");
             eprintln!("{ast:?}");

--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -1,6 +1,6 @@
 use super::instruction::{Capture, Instruction};
 use crate::builtins::Builtins;
-use crate::parser::{AstNode, BinaryOperator};
+use crate::parser::{AstNode, BinaryOperator, UnaryOperator};
 use crate::value::{Value, WqError, WqResult};
 use indexmap::IndexMap;
 
@@ -37,6 +37,70 @@ fn has_ctrl(node: &AstNode) -> bool {
         } => has_ctrl(object) || has_ctrl(index) || has_ctrl(value),
         AstNode::Assignment { value, .. } => has_ctrl(value),
         _ => false,
+    }
+}
+
+fn const_eval(node: &AstNode) -> Option<Value> {
+    use AstNode::*;
+    use BinaryOperator::*;
+    use UnaryOperator::*;
+
+    match node {
+        Literal(v) => Some(v.clone()),
+        List(items) => {
+            let mut values = Vec::with_capacity(items.len());
+            for item in items {
+                values.push(const_eval(item)?);
+            }
+            if values.iter().all(|v| matches!(v, Value::Int(_))) {
+                Some(Value::IntList(
+                    values
+                        .into_iter()
+                        .map(|v| {
+                            if let Value::Int(i) = v {
+                                i
+                            } else {
+                                unreachable!()
+                            }
+                        })
+                        .collect(),
+                ))
+            } else {
+                Some(Value::List(values))
+            }
+        }
+        UnaryOp { operator, operand } => {
+            let val = const_eval(operand)?;
+            match operator {
+                Negate => val.neg_value(),
+                Count => Some(Value::Int(val.len() as i64)),
+            }
+        }
+        BinaryOp {
+            left,
+            operator,
+            right,
+        } => {
+            let l = const_eval(left)?;
+            let r = const_eval(right)?;
+            match operator {
+                Add => l.add(&r),
+                Subtract => l.subtract(&r),
+                Multiply => l.multiply(&r),
+                Power => l.power(&r),
+                Divide => l.divide(&r),
+                DivideDot => l.divide_dot(&r),
+                Modulo => l.modulo(&r),
+                ModuloDot => l.modulo_dot(&r),
+                Equal => Some(l.equals(&r)),
+                NotEqual => Some(l.not_equals(&r)),
+                LessThan => Some(l.less_than(&r)),
+                LessThanOrEqual => Some(l.less_than_or_equal(&r)),
+                GreaterThan => Some(l.greater_than(&r)),
+                GreaterThanOrEqual => Some(l.greater_than_or_equal(&r)),
+            }
+        }
+        _ => None,
     }
 }
 
@@ -141,6 +205,11 @@ impl Compiler {
     }
 
     pub fn compile(&mut self, node: &AstNode) -> WqResult<()> {
+        if let Some(v) = const_eval(node) {
+            self.instructions.push(Instruction::LoadConst(v));
+            return Ok(());
+        }
+
         match node {
             AstNode::Literal(v) => self.instructions.push(Instruction::LoadConst(v.clone())),
             AstNode::Variable(name) => self.emit_load(name),
@@ -828,6 +897,55 @@ impl Compiler {
             if !changed {
                 break;
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folds_simple_addition() {
+        let mut c = Compiler::new();
+        let ast = AstNode::BinaryOp {
+            left: Box::new(AstNode::Literal(Value::Int(1))),
+            operator: BinaryOperator::Add,
+            right: Box::new(AstNode::Literal(Value::Int(1))),
+        };
+        c.compile(&ast).unwrap();
+        assert_eq!(c.instructions, vec![Instruction::LoadConst(Value::Int(2))]);
+    }
+
+    #[test]
+    fn folds_list_addition_to_int_list() {
+        let mut c = Compiler::new();
+        let l1 = AstNode::List(vec![
+            AstNode::Literal(Value::Int(1)),
+            AstNode::Literal(Value::Int(2)),
+            AstNode::Literal(Value::Int(3)),
+            AstNode::Literal(Value::Int(4)),
+        ]);
+        let l2 = AstNode::List(vec![
+            AstNode::Literal(Value::Int(3)),
+            AstNode::Literal(Value::Int(4)),
+            AstNode::Literal(Value::Int(5)),
+            AstNode::Literal(Value::Int(6)),
+        ]);
+        let ast = AstNode::BinaryOp {
+            left: Box::new(l1),
+            operator: BinaryOperator::Add,
+            right: Box::new(l2),
+        };
+        c.compile(&ast).unwrap();
+        assert_eq!(
+            c.instructions,
+            vec![Instruction::LoadConst(Value::IntList(vec![4, 6, 8, 10]))]
+        );
+        if let Instruction::LoadConst(val) = &c.instructions[0] {
+            assert_eq!(val.type_name_verbose(), "int-list");
+        } else {
+            panic!("expected LoadConst");
         }
     }
 }


### PR DESCRIPTION
example:
- `1+1`

before:
```
=====INST=====
LoadConst(Int(1))
LoadConst(Int(1))
BinaryOp(Add)
Return
```

now:
```
=====INST=====
LoadConst(Int(2))
Return
```

- `(1;2;3;4)+(3;4;5;6;7)`

before:
```
=====INST=====
LoadConst(Int(1))
LoadConst(Int(2))
LoadConst(Int(3))
LoadConst(Int(4))
MakeList(4)
LoadConst(Int(3))
LoadConst(Int(4))
LoadConst(Int(5))
LoadConst(Int(6))
LoadConst(Int(7))
MakeList(5)
BinaryOp(Add)
Return
```
now:
```
=====INST=====
LoadConst(List([Int(4), Int(6), Int(8), Int(10), Int(8)]))
Return
```