### PR TITLE
Fix iota bug

### DIFF
--- a/doc/builtins/list/iota.txt
+++ b/doc/builtins/list/iota.txt
@@ -5,3 +5,5 @@ iota <shape>
 Examples:
   iota 3      // (0;1;2)
   iota(2;3)   // ((0;1;2);(3;4;5))
+  iota 0      // ()
+  iota()      // 0

--- a/doc/builtins/list/shape.txt
+++ b/doc/builtins/list/shape.txt
@@ -1,3 +1,7 @@
 shape
 =====
 shape x
+
+Examples:
+  shape 42   // ()
+  shape ()   // 0

--- a/doc/builtins/plot/asciiplot.txt
+++ b/doc/builtins/plot/asciiplot.txt
@@ -3,5 +3,5 @@ asciiplot
 asciiplot[<numeric list | list of 2-element numeric lists>+]
 
 Examples:
-  asciiplot til 14               // dx = 1
+  asciiplot iota 14              // dx = 1
   asciiplot((0;0);(1;1);(2;4))

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -15,7 +15,7 @@ mod string;
 mod system;
 mod type_builtins;
 
-static TIL_CACHE: Lazy<Mutex<HashMap<i64, Value>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static IOTA_CACHE: Lazy<Mutex<HashMap<i64, Value>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 fn arity_error(func: &str, expected: &str, got: usize) -> WqError {
     WqError::ArityError(format!("{func} expects {expected}, got {got}"))


### PR DESCRIPTION
before:
```
wq[2] iota()

thread 'main' panicked at src/builtins/list.rs:18:42:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

now:
```
wq[1] iota()
▍ ()
```

not quite sure how should it behave, maybe throw an error instead?